### PR TITLE
[Feat/#2] 약 등록 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,10 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/java/backend/medsnap/MedsnapApplication.java
+++ b/src/main/java/backend/medsnap/MedsnapApplication.java
@@ -2,8 +2,10 @@ package backend.medsnap;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MedsnapApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/backend/medsnap/MedsnapApplication.java
+++ b/src/main/java/backend/medsnap/MedsnapApplication.java
@@ -2,10 +2,11 @@ package backend.medsnap;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
+@EnableJpaAuditing
 public class MedsnapApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
+++ b/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
@@ -3,6 +3,7 @@ package backend.medsnap.domain.medication.controller;
 import backend.medsnap.domain.medication.dto.request.MedicationCreateRequest;
 import backend.medsnap.domain.medication.dto.response.MedicationResponse;
 import backend.medsnap.domain.medication.service.MedicationService;
+import backend.medsnap.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,8 +20,13 @@ public class MedicationController implements MedicationSwagger {
 
     @Override
     @PostMapping
-    public ResponseEntity<MedicationResponse> createMedication(@RequestBody MedicationCreateRequest request) {
-        MedicationResponse response = medicationService.createMedication(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<ApiResponse<MedicationResponse>> createMedication(
+            @RequestBody MedicationCreateRequest request) {
+        try {
+            MedicationResponse response = medicationService.createMedication(request);
+            return ResponseEntity.status(201).body(ApiResponse.success(response));
+        } catch (Exception e) {
+            return ResponseEntity.status(400).body(ApiResponse.error(e.getMessage()));
+        }
     }
 }

--- a/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
+++ b/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
@@ -13,10 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/medications")
 @RequiredArgsConstructor
-public class MedicationController {
+public class MedicationController implements MedicationSwagger {
 
     private final MedicationService medicationService;
 
+    @Override
     @PostMapping
     public ResponseEntity<MedicationResponse> createMedication(@RequestBody MedicationCreateRequest request) {
         MedicationResponse response = medicationService.createMedication(request);

--- a/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
+++ b/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
@@ -1,0 +1,25 @@
+package backend.medsnap.domain.medication.controller;
+
+import backend.medsnap.domain.medication.dto.request.MedicationCreateRequest;
+import backend.medsnap.domain.medication.dto.response.MedicationResponse;
+import backend.medsnap.domain.medication.service.MedicationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/medications")
+@RequiredArgsConstructor
+public class MedicationController {
+
+    private final MedicationService medicationService;
+
+    @PostMapping
+    public ResponseEntity<MedicationResponse> createMedication(@RequestBody MedicationCreateRequest request) {
+        MedicationResponse response = medicationService.createMedication(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
+++ b/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
@@ -4,6 +4,7 @@ import backend.medsnap.domain.medication.dto.request.MedicationCreateRequest;
 import backend.medsnap.domain.medication.dto.response.MedicationResponse;
 import backend.medsnap.domain.medication.service.MedicationService;
 import backend.medsnap.global.dto.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,7 +22,7 @@ public class MedicationController implements MedicationSwagger {
     @Override
     @PostMapping
     public ResponseEntity<ApiResponse<MedicationResponse>> createMedication(
-            @RequestBody MedicationCreateRequest request) {
+            @RequestBody @Valid MedicationCreateRequest request) {
         try {
             MedicationResponse response = medicationService.createMedication(request);
             return ResponseEntity.status(201).body(ApiResponse.success(response));

--- a/src/main/java/backend/medsnap/domain/medication/controller/MedicationSwagger.java
+++ b/src/main/java/backend/medsnap/domain/medication/controller/MedicationSwagger.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -18,14 +19,17 @@ public interface MedicationSwagger {
     @Operation(summary = "약 등록", description = "새로운 약을 등록합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "약 등록 성공",
-                    content = @Content(schema = @Schema(implementation = MedicationResponse.class))),
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = backend.medsnap.global.dto.ApiResponse.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 요청",
-                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = backend.medsnap.global.dto.ApiResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 오류",
-                    content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = backend.medsnap.global.dto.ApiResponse.class)))
     })
     ResponseEntity<backend.medsnap.global.dto.ApiResponse<MedicationResponse>> createMedication(
             @Parameter(description = "약 등록 요청 정보", required = true)
-            @RequestBody MedicationCreateRequest request
+            @RequestBody @Valid MedicationCreateRequest request
     );
 }

--- a/src/main/java/backend/medsnap/domain/medication/controller/MedicationSwagger.java
+++ b/src/main/java/backend/medsnap/domain/medication/controller/MedicationSwagger.java
@@ -4,6 +4,8 @@ import backend.medsnap.domain.medication.dto.request.MedicationCreateRequest;
 import backend.medsnap.domain.medication.dto.response.MedicationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,11 +17,14 @@ public interface MedicationSwagger {
 
     @Operation(summary = "약 등록", description = "새로운 약을 등록합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "약 등록 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "500", description = "서버 오류")
+            @ApiResponse(responseCode = "201", description = "약 등록 성공",
+                    content = @Content(schema = @Schema(implementation = MedicationResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ResponseEntity<MedicationResponse> createMedication(
+    ResponseEntity<backend.medsnap.global.dto.ApiResponse<MedicationResponse>> createMedication(
             @Parameter(description = "약 등록 요청 정보", required = true)
             @RequestBody MedicationCreateRequest request
     );

--- a/src/main/java/backend/medsnap/domain/medication/controller/MedicationSwagger.java
+++ b/src/main/java/backend/medsnap/domain/medication/controller/MedicationSwagger.java
@@ -1,0 +1,26 @@
+package backend.medsnap.domain.medication.controller;
+
+import backend.medsnap.domain.medication.dto.request.MedicationCreateRequest;
+import backend.medsnap.domain.medication.dto.response.MedicationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Medication", description = "약 API")
+public interface MedicationSwagger {
+
+    @Operation(summary = "약 등록", description = "새로운 약을 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "약 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    ResponseEntity<MedicationResponse> createMedication(
+            @Parameter(description = "약 등록 요청 정보", required = true)
+            @RequestBody MedicationCreateRequest request
+    );
+}

--- a/src/main/java/backend/medsnap/domain/medication/controller/MedicationSwagger.java
+++ b/src/main/java/backend/medsnap/domain/medication/controller/MedicationSwagger.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "Medication", description = "약 API")
+@Tag(name = "medications", description = "약 API")
 public interface MedicationSwagger {
 
     @Operation(summary = "약 등록", description = "새로운 약을 등록합니다.")

--- a/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationCreateRequest.java
+++ b/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationCreateRequest.java
@@ -1,0 +1,24 @@
+package backend.medsnap.domain.medication.dto.request;
+
+import backend.medsnap.domain.medication.entity.DayOfWeek;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class MedicationCreateRequest{
+
+    private String name;
+    private String imageUrl;
+    private Boolean notifyCaregiver;
+    private Boolean preNotify;
+
+    @JsonFormat(pattern = "HH:mm")
+    private List<LocalTime> doseTimes;
+
+    private List<DayOfWeek> doseDays;
+}

--- a/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationCreateRequest.java
+++ b/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationCreateRequest.java
@@ -3,6 +3,9 @@ package backend.medsnap.domain.medication.dto.request;
 import backend.medsnap.domain.medication.entity.DayOfWeek;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,21 +31,27 @@ import java.util.List;
 public class MedicationCreateRequest{
 
     @Schema(description = "약 이름")
+    @NotBlank(message = "약 이름은 필수입니다")
     private String name;
 
     @Schema(description = "약 이미지 URL")
+    @NotBlank(message = "약 이미지 URL은 필수입니다")
     private String imageUrl;
 
     @Schema(description = "보호자 알림 여부")
+    @NotNull(message = "보호자 알림 여부는 필수입니다")
     private Boolean notifyCaregiver;
 
-    @Schema(description = "사전 알림 여부") 
+    @Schema(description = "사전 알림 여부")
+    @NotNull(message = "사전 알림 여부는 필수입니다")
     private Boolean preNotify;
 
     @Schema(description = "복용 시간 목록")
     @JsonFormat(pattern = "HH:mm")
+    @NotEmpty(message = "복용 시간은 최소 1개 이상이어야 합니다")
     private List<LocalTime> doseTimes;
 
     @Schema(description = "복용 요일 목록")
+    @NotEmpty(message = "복용 요일은 최소 1개 이상이어야 합니다")
     private List<DayOfWeek> doseDays;
 }

--- a/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationCreateRequest.java
+++ b/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationCreateRequest.java
@@ -2,6 +2,7 @@ package backend.medsnap.domain.medication.dto.request;
 
 import backend.medsnap.domain.medication.entity.DayOfWeek;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,15 +11,38 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "약 등록 요청", example = """
+    {
+      "name": "타이레놀",
+      "imageUrl": "https://example.com/image.jpg",
+      "notifyCaregiver": true,
+      "preNotify": true,
+      "doseTimes": ["09:00","21:00"],
+      "doseDays": [
+        "MON",
+        "TUE",
+        "WED"
+      ]
+    }
+    """)
 public class MedicationCreateRequest{
 
+    @Schema(description = "약 이름")
     private String name;
+
+    @Schema(description = "약 이미지 URL")
     private String imageUrl;
+
+    @Schema(description = "보호자 알림 여부")
     private Boolean notifyCaregiver;
+
+    @Schema(description = "사전 알림 여부") 
     private Boolean preNotify;
 
+    @Schema(description = "복용 시간 목록")
     @JsonFormat(pattern = "HH:mm")
     private List<LocalTime> doseTimes;
 
+    @Schema(description = "복용 요일 목록")
     private List<DayOfWeek> doseDays;
 }

--- a/src/main/java/backend/medsnap/domain/medication/dto/response/MedicationResponse.java
+++ b/src/main/java/backend/medsnap/domain/medication/dto/response/MedicationResponse.java
@@ -2,6 +2,7 @@ package backend.medsnap.domain.medication.dto.response;
 
 import backend.medsnap.domain.medication.entity.DayOfWeek;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,17 +12,50 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "약 정보 응답", example = """
+    {
+      "id": 1,
+      "name": "타이레놀",
+      "imageUrl": "https://example.com/image.jpg",
+      "notifyCaregiver": true,
+      "preNotify": true,
+      "doseTimes": ["09:00","21:00"],
+      "doseDays": [
+        "MON",
+        "TUE",
+        "WED"
+      ],
+      "createdAt": "2024-01-01T10:00:00",
+      "updatedAt": "2024-01-01T10:00:00"
+    }
+    """)
 public class MedicationResponse {
+    
+    @Schema(description = "약 ID")
     private Long id;
+    
+    @Schema(description = "약 이름")
     private String name;
+    
+    @Schema(description = "약 이미지 URL")
     private String imageUrl;
+    
+    @Schema(description = "보호자 알림 여부")
     private Boolean notifyCaregiver;
+    
+    @Schema(description = "사전 알림 여부")
     private Boolean preNotify;
 
+    @Schema(description = "복용 시간 목록")
     @JsonFormat(pattern = "HH:mm")
     private List<LocalTime> doseTimes;
 
+    @Schema(description = "복용 요일 목록")
     private List<DayOfWeek> doseDays;
+    
+    @Schema(description = "생성 시간")
     private final LocalDateTime createdAt;
+    
+    @Schema(description = "수정 시간")
     private final LocalDateTime updatedAt;
 }

--- a/src/main/java/backend/medsnap/domain/medication/dto/response/MedicationResponse.java
+++ b/src/main/java/backend/medsnap/domain/medication/dto/response/MedicationResponse.java
@@ -1,0 +1,27 @@
+package backend.medsnap.domain.medication.dto.response;
+
+import backend.medsnap.domain.medication.entity.DayOfWeek;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class MedicationResponse {
+    private Long id;
+    private String name;
+    private String imageUrl;
+    private Boolean notifyCaregiver;
+    private Boolean preNotify;
+
+    @JsonFormat(pattern = "HH:mm")
+    private List<LocalTime> doseTimes;
+
+    private List<DayOfWeek> doseDays;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+}

--- a/src/main/java/backend/medsnap/domain/medication/entity/DayOfWeek.java
+++ b/src/main/java/backend/medsnap/domain/medication/entity/DayOfWeek.java
@@ -10,6 +10,9 @@ public enum DayOfWeek {
     );
 
     public static List<DayOfWeek> expandDays(List<DayOfWeek> requestDays) {
-        return requestDays.contains(DAILY) ? ALL_DAYS : requestDays;
+        if (requestDays == null || requestDays.isEmpty()) {
+            throw new IllegalArgumentException("Request days cannot be null or empty");
+        }
+        return requestDays.contains(DAILY) ? List.copyOf(ALL_DAYS) : List.copyOf(requestDays);
     }
 }

--- a/src/main/java/backend/medsnap/domain/medication/entity/DayOfWeek.java
+++ b/src/main/java/backend/medsnap/domain/medication/entity/DayOfWeek.java
@@ -1,0 +1,12 @@
+package backend.medsnap.domain.medication.entity;
+
+public enum DayOfWeek {
+    MON,
+    TUE,
+    WED,
+    THU,
+    FRI,
+    SAT,
+    SUN,
+    DAILY
+}

--- a/src/main/java/backend/medsnap/domain/medication/entity/DayOfWeek.java
+++ b/src/main/java/backend/medsnap/domain/medication/entity/DayOfWeek.java
@@ -1,12 +1,15 @@
 package backend.medsnap.domain.medication.entity;
 
+import java.util.List;
+
 public enum DayOfWeek {
-    MON,
-    TUE,
-    WED,
-    THU,
-    FRI,
-    SAT,
-    SUN,
-    DAILY
+    MON, TUE, WED, THU, FRI, SAT, SUN, DAILY;
+
+    public static final List<DayOfWeek> ALL_DAYS = List.of(
+            MON, TUE, WED, THU, FRI, SAT, SUN
+    );
+
+    public static List<DayOfWeek> expandDays(List<DayOfWeek> requestDays) {
+        return requestDays.contains(DAILY) ? ALL_DAYS : requestDays;
+    }
 }

--- a/src/main/java/backend/medsnap/domain/medication/entity/Medication.java
+++ b/src/main/java/backend/medsnap/domain/medication/entity/Medication.java
@@ -20,10 +20,10 @@ public class Medication extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, length = 500)
+    @Column(nullable = false)
     private String imageUrl;
 
     @Column(nullable = false)

--- a/src/main/java/backend/medsnap/domain/medication/entity/Medication.java
+++ b/src/main/java/backend/medsnap/domain/medication/entity/Medication.java
@@ -1,0 +1,42 @@
+package backend.medsnap.domain.medication.entity;
+
+import backend.medsnap.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "medications")
+public class Medication extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String imageUrl;
+
+    private Boolean notifyCaregiver;
+
+    private Boolean preNotify;
+
+    @OneToMany(mappedBy = "medication", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<MedicationAlarm> alarms = new ArrayList<>();
+
+    @Builder
+    public Medication(String name, String imageUrl, Boolean notifyCaregiver, Boolean preNotify) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.notifyCaregiver = notifyCaregiver;
+        this.preNotify = preNotify;
+    }
+
+}

--- a/src/main/java/backend/medsnap/domain/medication/entity/Medication.java
+++ b/src/main/java/backend/medsnap/domain/medication/entity/Medication.java
@@ -20,12 +20,16 @@ public class Medication extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 100)
     private String name;
 
+    @Column(nullable = false, length = 500)
     private String imageUrl;
 
+    @Column(nullable = false)
     private Boolean notifyCaregiver;
 
+    @Column(nullable = false)
     private Boolean preNotify;
 
     @OneToMany(mappedBy = "medication", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
@@ -38,5 +42,4 @@ public class Medication extends BaseEntity {
         this.notifyCaregiver = notifyCaregiver;
         this.preNotify = preNotify;
     }
-
 }

--- a/src/main/java/backend/medsnap/domain/medication/entity/MedicationAlarm.java
+++ b/src/main/java/backend/medsnap/domain/medication/entity/MedicationAlarm.java
@@ -21,10 +21,12 @@ public class MedicationAlarm extends BaseEntity {
 
     // 복용 시간
     @JsonFormat(pattern = "HH:mm")
+    @Column(nullable = false)
     private LocalTime doseTime;
 
     // 복용 요일
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private DayOfWeek dayOfWeek;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/backend/medsnap/domain/medication/entity/MedicationAlarm.java
+++ b/src/main/java/backend/medsnap/domain/medication/entity/MedicationAlarm.java
@@ -1,0 +1,38 @@
+package backend.medsnap.domain.medication.entity;
+
+import backend.medsnap.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MedicationAlarm extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 복용 시간
+    private LocalDateTime doseTime;
+
+    // 복용 요일
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek dayOfWeek;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "medication_id", insertable = false, updatable = false)
+    private Medication medication;
+
+    @Builder
+    public MedicationAlarm(LocalDateTime doseTime, DayOfWeek dayOfWeek, Medication medication) {
+        this.doseTime = doseTime;
+        this.dayOfWeek = dayOfWeek;
+        this.medication = medication;
+    }
+}

--- a/src/main/java/backend/medsnap/domain/medication/entity/MedicationAlarm.java
+++ b/src/main/java/backend/medsnap/domain/medication/entity/MedicationAlarm.java
@@ -1,13 +1,14 @@
 package backend.medsnap.domain.medication.entity;
 
 import backend.medsnap.global.entity.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -19,7 +20,8 @@ public class MedicationAlarm extends BaseEntity {
     private Long id;
 
     // 복용 시간
-    private LocalDateTime doseTime;
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime doseTime;
 
     // 복용 요일
     @Enumerated(EnumType.STRING)
@@ -30,7 +32,7 @@ public class MedicationAlarm extends BaseEntity {
     private Medication medication;
 
     @Builder
-    public MedicationAlarm(LocalDateTime doseTime, DayOfWeek dayOfWeek, Medication medication) {
+    public MedicationAlarm(LocalTime doseTime, DayOfWeek dayOfWeek, Medication medication) {
         this.doseTime = doseTime;
         this.dayOfWeek = dayOfWeek;
         this.medication = medication;

--- a/src/main/java/backend/medsnap/domain/medication/entity/MedicationAlarm.java
+++ b/src/main/java/backend/medsnap/domain/medication/entity/MedicationAlarm.java
@@ -30,7 +30,7 @@ public class MedicationAlarm extends BaseEntity {
     private DayOfWeek dayOfWeek;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "medication_id", insertable = false, updatable = false)
+    @JoinColumn(name = "medication_id", nullable = false)
     private Medication medication;
 
     @Builder

--- a/src/main/java/backend/medsnap/domain/medication/repository/MedicationAlarmRepository.java
+++ b/src/main/java/backend/medsnap/domain/medication/repository/MedicationAlarmRepository.java
@@ -1,0 +1,9 @@
+package backend.medsnap.domain.medication.repository;
+
+import backend.medsnap.domain.medication.entity.MedicationAlarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MedicationAlarmRepository extends JpaRepository<MedicationAlarm, Long> {
+}

--- a/src/main/java/backend/medsnap/domain/medication/repository/MedicationRepository.java
+++ b/src/main/java/backend/medsnap/domain/medication/repository/MedicationRepository.java
@@ -1,0 +1,9 @@
+package backend.medsnap.domain.medication.repository;
+
+import backend.medsnap.domain.medication.entity.Medication;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MedicationRepository extends JpaRepository<Medication, Long> {
+}

--- a/src/main/java/backend/medsnap/domain/medication/service/MedicationService.java
+++ b/src/main/java/backend/medsnap/domain/medication/service/MedicationService.java
@@ -1,0 +1,88 @@
+package backend.medsnap.domain.medication.service;
+
+import backend.medsnap.domain.medication.dto.request.MedicationCreateRequest;
+import backend.medsnap.domain.medication.dto.response.MedicationResponse;
+import backend.medsnap.domain.medication.entity.DayOfWeek;
+import backend.medsnap.domain.medication.entity.Medication;
+import backend.medsnap.domain.medication.entity.MedicationAlarm;
+import backend.medsnap.domain.medication.repository.MedicationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MedicationService {
+
+    private final MedicationRepository medicationRepository;
+
+    @Transactional
+    public MedicationResponse createMedication(MedicationCreateRequest request) {
+
+        // 1. Medication 생성
+        Medication medication = Medication.builder()
+                .name(request.getName())
+                .imageUrl(request.getImageUrl())
+                .notifyCaregiver(request.getNotifyCaregiver())
+                .preNotify(request.getPreNotify())
+                .build();
+
+        // 2. Alarm 생성
+        createAlarms(medication, request);
+
+        // 3. 저장
+        Medication savedMedication = medicationRepository.save(medication);
+
+        // 4. response 반환
+        return MedicationResponse.builder()
+                .id(savedMedication.getId())
+                .name(savedMedication.getName())
+                .imageUrl(savedMedication.getImageUrl())
+                .notifyCaregiver(savedMedication.getNotifyCaregiver())
+                .preNotify(savedMedication.getPreNotify())
+                .doseTimes(request.getDoseTimes())
+                .doseDays(request.getDoseDays())
+                .createdAt(savedMedication.getCreatedAt())
+                .updatedAt(savedMedication.getUpdatedAt())
+                .build();
+    }
+
+    private void createAlarms(Medication medication, MedicationCreateRequest request) {
+        List<MedicationAlarm> alarms = new ArrayList<>();
+
+        if (request.getDoseDays().contains(DayOfWeek.DAILY)) {
+            //매일 복용 -> 월~일 전체 요일 생성
+            DayOfWeek[] allDays = {
+                    DayOfWeek.MON, DayOfWeek.TUE, DayOfWeek.WED,
+                    DayOfWeek.THU, DayOfWeek.FRI, DayOfWeek.SAT, DayOfWeek.SUN
+            };
+
+            for (DayOfWeek day : allDays) {
+                for (LocalTime time : request.getDoseTimes()) {
+                    alarms.add(createAlarm(medication, time, day));
+                }
+            }
+        } else {
+            // 특정 요일에만 복용
+            for (DayOfWeek day : request.getDoseDays()) {
+                for (LocalTime time : request.getDoseTimes()) {
+                    alarms.add(createAlarm(medication, time, day));
+                }
+            }
+        }
+
+        medication.getAlarms().addAll(alarms);
+    }
+
+    private MedicationAlarm createAlarm(Medication medication, LocalTime time, DayOfWeek day) {
+        return MedicationAlarm.builder()
+                .doseTime(time)
+                .dayOfWeek(day)
+                .medication(medication)
+                .build();
+    }
+}

--- a/src/main/java/backend/medsnap/global/dto/ApiResponse.java
+++ b/src/main/java/backend/medsnap/global/dto/ApiResponse.java
@@ -1,0 +1,29 @@
+package backend.medsnap.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private final Boolean success;
+    private final T data;
+    private final String error;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> error(String errorMessage) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .data(null)
+                .error(errorMessage)
+                .build();
+    }
+}

--- a/src/main/java/backend/medsnap/global/entity/BaseEntity.java
+++ b/src/main/java/backend/medsnap/global/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package backend.medsnap.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @CreatedBy
+    private String createdBy;
+
+    @LastModifiedBy
+    private String updatedBy;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,17 @@
 spring.application.name=medsnap
+
+# Swagger/OpenAPI Configuration
+springdoc.api-docs.path=/api/v1/api-docs
+springdoc.swagger-ui.path=/api/v1/docs
+springdoc.swagger-ui.operations-sorter=method
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.try-it-out-enabled=true
+springdoc.swagger-ui.filter=true
+
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true


### PR DESCRIPTION
## 📖개요
약 등록 api 구현
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #2 
<br>
<br>

## 💻작업사항

- 약 등록 API 구현<br>

## 💡작성한 이슈 외에 작업한 사항

- 공통 response 구조 적용<br>

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 약 등록 API 추가(POST /api/v1/medications) — 요일/시간 기반 알림 생성 및 반환.
  - 표준 응답 포맷(ApiResponse) 도입으로 성공/오류 응답 일관화.
  - 엔티티 기반 알림(시간/요일), 응답용 DTO 및 자동 생성/수정 시간 포함.

- API 문서
  - OpenAPI/Swagger UI 제공(/api/v1/api-docs, /api/v1/docs).

- 설정
  - JPA 감사(생성/수정자·일시) 활성화 및 개발용 인메모리 DB(H2) 설정, 웹/JPA 의존성 추가.

- 잡무
  - .env를 .gitignore에 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->