### PR TITLE
[Feat/#23] FAQ 조회 API 구현

### DIFF
--- a/src/main/java/backend/medsnap/domain/faq/controller/FaqController.java
+++ b/src/main/java/backend/medsnap/domain/faq/controller/FaqController.java
@@ -12,6 +12,8 @@ import backend.medsnap.domain.faq.service.FaqService;
 import backend.medsnap.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("api/v1/faq")
 @RequiredArgsConstructor
@@ -27,6 +29,14 @@ public class FaqController implements FaqSwagger {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(HttpStatus.CREATED, response));
+    }
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<FaqResponse>>> getAllFaq() {
+        List<FaqResponse> response = faqService.getAllFaq();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Override

--- a/src/main/java/backend/medsnap/domain/faq/controller/FaqSwagger.java
+++ b/src/main/java/backend/medsnap/domain/faq/controller/FaqSwagger.java
@@ -104,6 +104,73 @@ public interface FaqSwagger {
                     @Valid
                     FaqRequest request);
 
+    @Operation(summary = "FAQ 전체 조회", description = "모든 FAQ 목록을 조회합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "FAQ 목록 조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                backend.medsnap.global.dto
+                                                                        .ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                        {
+                          "code": "SUCCESS",
+                          "httpStatus": 200,
+                          "message": "요청이 성공적으로 처리되었습니다.",
+                          "data": [
+                            {
+                              "id": 1,
+                              "question": "약을 복용하는 시간을 변경할 수 있나요?",
+                              "answer": "네, 언제든지 약 복용 시간을 변경할 수 있습니다. 앱에서 알람 설정을 수정하시면 됩니다.",
+                              "category": "MEDICATION_STATUS",
+                              "createdAt": "2024-01-01T10:00:00",
+                              "updatedAt": "2024-01-01T10:00:00"
+                            },
+                            {
+                              "id": 2,
+                              "question": "알람이 울리지 않을 때는 어떻게 하나요?",
+                              "answer": "알람이 울리지 않는 경우, 디바이스의 알림 설정을 확인하고 앱의 알림 권한이 허용되어 있는지 확인해주세요.",
+                              "category": "ALARM",
+                              "createdAt": "2024-01-01T11:00:00",
+                              "updatedAt": "2024-01-01T11:00:00"
+                            }
+                          ]
+                        }
+                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "500",
+                        description = "서버 오류",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                backend.medsnap.global.dto
+                                                                        .ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                        {
+                          "code": "C001",
+                          "httpStatus": 500,
+                          "message": "내부 서버 오류가 발생했습니다.",
+                          "data": null
+                        }
+                        """)))
+            })
+    ResponseEntity<backend.medsnap.global.dto.ApiResponse<java.util.List<FaqResponse>>> getAllFaq();
+
     @Operation(summary = "FAQ 수정", description = "기존 FAQ를 수정합니다.")
     @io.swagger.v3.oas.annotations.parameters.RequestBody(
             description = "FAQ 수정 요청",

--- a/src/main/java/backend/medsnap/domain/faq/service/FaqService.java
+++ b/src/main/java/backend/medsnap/domain/faq/service/FaqService.java
@@ -11,6 +11,9 @@ import backend.medsnap.domain.faq.repository.FaqRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -31,14 +34,16 @@ public class FaqService {
 
         Faq savedFaq = faqRepository.save(faq);
 
-        return FaqResponse.builder()
-                .id(savedFaq.getId())
-                .question(savedFaq.getQuestion())
-                .answer(savedFaq.getAnswer())
-                .category(savedFaq.getCategory())
-                .createdAt(savedFaq.getCreatedAt())
-                .updatedAt(savedFaq.getUpdatedAt())
-                .build();
+        return getFaqResponse(savedFaq);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FaqResponse> getAllFaq() {
+        log.info("전체 FAQ 목록 조회 시작");
+
+        return faqRepository.findAll().stream()
+                .map(this::getFaqResponse)
+                .collect(Collectors.toList());
     }
 
     @Transactional
@@ -50,14 +55,7 @@ public class FaqService {
 
         faq.update(request.getQuestion(), request.getAnswer(), request.getCategory());
 
-        return FaqResponse.builder()
-                .id(faq.getId())
-                .question(faq.getQuestion())
-                .answer(faq.getAnswer())
-                .category(faq.getCategory())
-                .createdAt(faq.getCreatedAt())
-                .updatedAt(faq.getUpdatedAt())
-                .build();
+        return getFaqResponse(faq);
     }
 
     @Transactional
@@ -69,5 +67,16 @@ public class FaqService {
 
         faqRepository.delete(faq);
         log.info("FAQ ID: {}가 삭제되었습니다.", faqId);
+    }
+
+    private FaqResponse getFaqResponse(Faq faq) {
+        return FaqResponse.builder()
+                .id(faq.getId())
+                .question(faq.getQuestion())
+                .answer(faq.getAnswer())
+                .category(faq.getCategory())
+                .createdAt(faq.getCreatedAt())
+                .updatedAt(faq.getUpdatedAt())
+                .build();
     }
 }


### PR DESCRIPTION
## 📖개요
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #23 
<br>
<br>

## 💻작업사항

- <br>

## 💡작성한 이슈 외에 작업한 사항

- <br>

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 전체 FAQ 목록을 조회하는 공개 GET 엔드포인트가 추가되었습니다. 클라이언트는 질문, 답변, 카테고리, 생성/수정일을 포함한 모든 FAQ를 한 번에 받아볼 수 있으며, 표준 응답 형식과 함께 200 OK로 반환됩니다. 기존 생성/수정/삭제 기능에는 영향이 없습니다.
- 문서화
  - Swagger 문서에 전체 조회 엔드포인트가 추가되어 200/500 응답 예시와 함께 확인할 수 있습니다. API 탐색성과 연동 편의성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->