### PR TITLE
[Feat/#27] 애플 로그인 구현, refresh token 암호화

### DIFF
--- a/src/main/java/backend/medsnap/domain/auth/controller/AuthController.java
+++ b/src/main/java/backend/medsnap/domain/auth/controller/AuthController.java
@@ -1,22 +1,24 @@
 package backend.medsnap.domain.auth.controller;
 
-import backend.medsnap.domain.auth.dto.request.LoginRequest;
-import backend.medsnap.domain.auth.dto.request.SignupRequest;
-import backend.medsnap.domain.auth.dto.token.TokenPair;
-import backend.medsnap.domain.auth.service.AuthService;
-import backend.medsnap.global.dto.ApiResponse;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import backend.medsnap.domain.auth.dto.request.LoginRequest;
+import backend.medsnap.domain.auth.dto.request.SignupRequest;
+import backend.medsnap.domain.auth.dto.token.TokenPair;
+import backend.medsnap.domain.auth.service.AuthService;
+import backend.medsnap.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class AuthController implements AuthSwagger{
+public class AuthController implements AuthSwagger {
 
     private final AuthService authService;
 
@@ -29,7 +31,8 @@ public class AuthController implements AuthSwagger{
 
     @Override
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<TokenPair>> signup(@Valid @RequestBody SignupRequest request) {
+    public ResponseEntity<ApiResponse<TokenPair>> signup(
+            @Valid @RequestBody SignupRequest request) {
 
         return ResponseEntity.ok(authService.signup(request));
     }

--- a/src/main/java/backend/medsnap/domain/auth/controller/AuthSwagger.java
+++ b/src/main/java/backend/medsnap/domain/auth/controller/AuthSwagger.java
@@ -1,5 +1,10 @@
 package backend.medsnap.domain.auth.controller;
 
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
 import backend.medsnap.domain.auth.dto.request.LoginRequest;
 import backend.medsnap.domain.auth.dto.request.SignupRequest;
 import backend.medsnap.domain.auth.dto.token.TokenPair;
@@ -10,23 +15,24 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "auth", description = "Auth API")
 public interface AuthSwagger {
 
     @Operation(summary = "로그인", description = "OIDC ID 토큰을 사용하여 로그인합니다.")
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "로그인 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "로그인 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                             {
                                               "code": "SUCCESS",
                                               "httpStatus": 200,
@@ -37,18 +43,18 @@ public interface AuthSwagger {
                                               },
                                               "error": null
                                             }
-                                            """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "가입되지 않은 소셜 계정 (회원가입 필요)",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
+                                            """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "가입되지 않은 소셜 계정 (회원가입 필요)",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                             {
                                               "code": "A002",
                                               "httpStatus": 404,
@@ -56,18 +62,18 @@ public interface AuthSwagger {
                                               "data": null,
                                               "error": null
                                             }
-                                            """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400",
-                    description = "입력값 검증 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
+                                            """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "입력값 검증 실패",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                             {
                                               "code": "C002",
                                               "httpStatus": 400,
@@ -75,23 +81,24 @@ public interface AuthSwagger {
                                               "data": null,
                                               "error": null
                                             }
-                                            """
-                            )
-                    )
-            )
-    })
+                                            """)))
+            })
     ResponseEntity<ApiResponse<TokenPair>> login(@Valid @RequestBody LoginRequest request);
 
     @Operation(summary = "회원가입", description = "OIDC ID 토큰과 사용자 정보를 사용하여 회원가입합니다.")
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "회원가입 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "회원가입 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                             {
                                               "code": "SUCCESS",
                                               "httpStatus": 200,
@@ -102,18 +109,18 @@ public interface AuthSwagger {
                                               },
                                               "error": null
                                             }
-                                            """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "409",
-                    description = "이미 가입된 소셜 계정",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
+                                            """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "409",
+                        description = "이미 가입된 소셜 계정",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                             {
                                               "code": "A003",
                                               "httpStatus": 409,
@@ -121,18 +128,18 @@ public interface AuthSwagger {
                                               "data": null,
                                               "error": null
                                             }
-                                            """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400",
-                    description = "입력값 검증 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
+                                            """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "입력값 검증 실패",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                             {
                                               "code": "C002",
                                               "httpStatus": 400,
@@ -140,10 +147,7 @@ public interface AuthSwagger {
                                               "data": null,
                                               "error": null
                                             }
-                                            """
-                            )
-                    )
-            )
-    })
+                                            """)))
+            })
     ResponseEntity<ApiResponse<TokenPair>> signup(@Valid @RequestBody SignupRequest request);
 }

--- a/src/main/java/backend/medsnap/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/backend/medsnap/domain/auth/dto/request/LoginRequest.java
@@ -1,8 +1,9 @@
 package backend.medsnap.domain.auth.dto.request;
 
-import backend.medsnap.domain.user.entity.Provider;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+
+import backend.medsnap.domain.user.entity.Provider;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/backend/medsnap/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/backend/medsnap/domain/auth/dto/request/SignupRequest.java
@@ -1,12 +1,14 @@
 package backend.medsnap.domain.auth.dto.request;
 
-import backend.medsnap.domain.user.entity.Provider;
+import java.time.LocalDate;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
+
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDate;
+import backend.medsnap.domain.user.entity.Provider;
+import lombok.Getter;
 
 @Getter
 public class SignupRequest {

--- a/src/main/java/backend/medsnap/domain/auth/exception/CryptoDecryptFailedException.java
+++ b/src/main/java/backend/medsnap/domain/auth/exception/CryptoDecryptFailedException.java
@@ -1,0 +1,12 @@
+package backend.medsnap.domain.auth.exception;
+
+import backend.medsnap.global.exception.BusinessException;
+import backend.medsnap.global.exception.ErrorCode;
+
+/** 복호화 실패 */
+public class CryptoDecryptFailedException extends BusinessException {
+
+    public CryptoDecryptFailedException() {
+        super(ErrorCode.AUTH_CRYPTO_DECRYPT_FAIL);
+    }
+}

--- a/src/main/java/backend/medsnap/domain/auth/exception/CryptoEncryptFailedException.java
+++ b/src/main/java/backend/medsnap/domain/auth/exception/CryptoEncryptFailedException.java
@@ -1,0 +1,12 @@
+package backend.medsnap.domain.auth.exception;
+
+import backend.medsnap.global.exception.BusinessException;
+import backend.medsnap.global.exception.ErrorCode;
+
+/** 암호화 실패 */
+public class CryptoEncryptFailedException extends BusinessException {
+
+    public CryptoEncryptFailedException() {
+        super(ErrorCode.AUTH_CRYPTO_ENCRYPT_FAIL);
+    }
+}

--- a/src/main/java/backend/medsnap/domain/auth/exception/CryptoKeyInvalidException.java
+++ b/src/main/java/backend/medsnap/domain/auth/exception/CryptoKeyInvalidException.java
@@ -1,0 +1,12 @@
+package backend.medsnap.domain.auth.exception;
+
+import backend.medsnap.global.exception.BusinessException;
+import backend.medsnap.global.exception.ErrorCode;
+
+/** 키 형식/길이 오류 */
+public class CryptoKeyInvalidException extends BusinessException {
+
+    public CryptoKeyInvalidException() {
+        super(ErrorCode.AUTH_CRYPTO_KEY_INVALID);
+    }
+}

--- a/src/main/java/backend/medsnap/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/backend/medsnap/domain/auth/jwt/JwtTokenProvider.java
@@ -1,15 +1,17 @@
 package backend.medsnap.domain.auth.jwt;
 
-import backend.medsnap.domain.auth.dto.token.TokenPair;
-import backend.medsnap.domain.user.entity.User;
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+
+import backend.medsnap.domain.auth.dto.token.TokenPair;
+import backend.medsnap.domain.user.entity.User;
 
 @Component
 public class JwtTokenProvider {
@@ -23,8 +25,7 @@ public class JwtTokenProvider {
             @Value("${jwt.secret}") String secretKey,
             @Value("${jwt.issuer}") String issuer,
             @Value("${jwt.access-token-validity-hours}") long accessTokenValidityHours,
-            @Value("${jwt.refresh-token-validity-days}") long refreshTokenValidityDays
-    ) {
+            @Value("${jwt.refresh-token-validity-days}") long refreshTokenValidityDays) {
         this.algorithm = Algorithm.HMAC256(secretKey);
         this.issuer = issuer;
         this.accessTokenValidityHours = accessTokenValidityHours;

--- a/src/main/java/backend/medsnap/domain/auth/service/AuthService.java
+++ b/src/main/java/backend/medsnap/domain/auth/service/AuthService.java
@@ -49,8 +49,9 @@ public class AuthService {
         // 자체 JWT 발급
         TokenPair tokenPair = jwtTokenProvider.createTokenPair(user);
 
+        // Refresh Token만 암호화하여 DB에 저장
         String encryptedRefreshToken = aesGcmEncryptor.encrypt(tokenPair.getRefreshToken());
-        user.updateTokens(tokenPair.getAccessToken(), encryptedRefreshToken);
+        user.updateRefreshToken(encryptedRefreshToken);
 
         return ApiResponse.success(tokenPair);
     }
@@ -84,8 +85,9 @@ public class AuthService {
         // 자체 JWT 발급
         TokenPair tokenPair = jwtTokenProvider.createTokenPair(newUser);
 
+        // Refresh Token만 암호화하여 DB에 저장
         String encryptedRefreshToken = aesGcmEncryptor.encrypt(tokenPair.getRefreshToken());
-        newUser.updateTokens(tokenPair.getAccessToken(), encryptedRefreshToken);
+        newUser.updateRefreshToken(encryptedRefreshToken);
 
         return ApiResponse.success(tokenPair);
     }

--- a/src/main/java/backend/medsnap/domain/auth/service/AuthService.java
+++ b/src/main/java/backend/medsnap/domain/auth/service/AuthService.java
@@ -11,6 +11,7 @@ import backend.medsnap.domain.user.entity.SocialAccount;
 import backend.medsnap.domain.user.entity.User;
 import backend.medsnap.domain.user.repository.SocialAccountRepository;
 import backend.medsnap.domain.user.repository.UserRepository;
+import backend.medsnap.global.crypto.AesGcmEncryptor;
 import backend.medsnap.global.dto.ApiResponse;
 import backend.medsnap.infra.oauth.exception.OidcVerificationException;
 import backend.medsnap.infra.oauth.verifier.AbstractOidcVerifier;
@@ -30,6 +31,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final SocialAccountRepository socialAccountRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AesGcmEncryptor aesGcmEncryptor;
 
     public ApiResponse<TokenPair> login(LoginRequest request) {
 
@@ -46,7 +48,9 @@ public class AuthService {
 
         // 자체 JWT 발급
         TokenPair tokenPair = jwtTokenProvider.createTokenPair(user);
-        user.updateTokens(tokenPair.getAccessToken(), tokenPair.getRefreshToken());
+
+        String encryptedRefreshToken = aesGcmEncryptor.encrypt(tokenPair.getRefreshToken());
+        user.updateTokens(tokenPair.getAccessToken(), encryptedRefreshToken);
 
         return ApiResponse.success(tokenPair);
     }
@@ -79,7 +83,9 @@ public class AuthService {
 
         // 자체 JWT 발급
         TokenPair tokenPair = jwtTokenProvider.createTokenPair(newUser);
-        newUser.updateTokens(tokenPair.getAccessToken(), tokenPair.getRefreshToken());
+
+        String encryptedRefreshToken = aesGcmEncryptor.encrypt(tokenPair.getRefreshToken());
+        newUser.updateTokens(tokenPair.getAccessToken(), encryptedRefreshToken);
 
         return ApiResponse.success(tokenPair);
     }

--- a/src/main/java/backend/medsnap/domain/faq/controller/FaqController.java
+++ b/src/main/java/backend/medsnap/domain/faq/controller/FaqController.java
@@ -1,5 +1,7 @@
 package backend.medsnap.domain.faq.controller;
 
+import java.util.List;
+
 import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
@@ -11,8 +13,6 @@ import backend.medsnap.domain.faq.dto.response.FaqResponse;
 import backend.medsnap.domain.faq.service.FaqService;
 import backend.medsnap.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("api/v1/faqs")

--- a/src/main/java/backend/medsnap/domain/faq/service/FaqService.java
+++ b/src/main/java/backend/medsnap/domain/faq/service/FaqService.java
@@ -1,5 +1,8 @@
 package backend.medsnap.domain.faq.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,9 +13,6 @@ import backend.medsnap.domain.faq.exception.FaqNotFoundException;
 import backend.medsnap.domain.faq.repository.FaqRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/src/main/java/backend/medsnap/domain/user/entity/Provider.java
+++ b/src/main/java/backend/medsnap/domain/user/entity/Provider.java
@@ -3,5 +3,6 @@ package backend.medsnap.domain.user.entity;
 public enum Provider {
     GOOGLE,
     KAKAO,
-    NAVER
+    NAVER,
+    APPLE
 }

--- a/src/main/java/backend/medsnap/domain/user/entity/Role.java
+++ b/src/main/java/backend/medsnap/domain/user/entity/Role.java
@@ -1,5 +1,6 @@
 package backend.medsnap.domain.user.entity;
 
 public enum Role {
-    USER, ADMIN
+    USER,
+    ADMIN
 }

--- a/src/main/java/backend/medsnap/domain/user/entity/SocialAccount.java
+++ b/src/main/java/backend/medsnap/domain/user/entity/SocialAccount.java
@@ -1,7 +1,8 @@
 package backend.medsnap.domain.user.entity;
 
-import backend.medsnap.global.entity.BaseEntity;
 import jakarta.persistence.*;
+
+import backend.medsnap.global.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,12 +12,10 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "social_accounts",
         uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "uk_social_provider_user",
-                        columnNames = {"provider", "provider_user_id"}
-                )
-        }
-)
+            @UniqueConstraint(
+                    name = "uk_social_provider_user",
+                    columnNames = {"provider", "provider_user_id"})
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SocialAccount extends BaseEntity {

--- a/src/main/java/backend/medsnap/domain/user/entity/User.java
+++ b/src/main/java/backend/medsnap/domain/user/entity/User.java
@@ -1,15 +1,16 @@
 package backend.medsnap.domain.user.entity;
 
-import backend.medsnap.global.entity.BaseEntity;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.persistence.*;
+
+import backend.medsnap.global.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "users")

--- a/src/main/java/backend/medsnap/domain/user/entity/User.java
+++ b/src/main/java/backend/medsnap/domain/user/entity/User.java
@@ -32,8 +32,6 @@ public class User extends BaseEntity {
 
     private String caregiverPhone;
 
-    private String accessToken;
-
     private String refreshToken;
 
     private Boolean isPushConsent;
@@ -50,9 +48,8 @@ public class User extends BaseEntity {
         this.isPushConsent = isPushConsent;
     }
 
-    // 자체 JWT 업데이트
-    public void updateTokens(String accessToken, String refreshToken) {
-        this.accessToken = accessToken;
+    // Refresh Token 업데이트 (Access Token은 DB에 저장하지 않음)
+    public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/backend/medsnap/domain/user/repository/SocialAccountRepository.java
+++ b/src/main/java/backend/medsnap/domain/user/repository/SocialAccountRepository.java
@@ -1,14 +1,16 @@
 package backend.medsnap.domain.user.repository;
 
-import backend.medsnap.domain.user.entity.Provider;
-import backend.medsnap.domain.user.entity.SocialAccount;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import backend.medsnap.domain.user.entity.Provider;
+import backend.medsnap.domain.user.entity.SocialAccount;
 
 @Repository
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
 
-    Optional<SocialAccount> findByProviderAndProviderUserId(Provider provider, String providerUserId);
+    Optional<SocialAccount> findByProviderAndProviderUserId(
+            Provider provider, String providerUserId);
 }

--- a/src/main/java/backend/medsnap/domain/user/repository/UserRepository.java
+++ b/src/main/java/backend/medsnap/domain/user/repository/UserRepository.java
@@ -1,9 +1,9 @@
 package backend.medsnap.domain.user.repository;
 
-import backend.medsnap.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import backend.medsnap.domain.user.entity.User;
+
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
-}
+public interface UserRepository extends JpaRepository<User, Long> {}

--- a/src/main/java/backend/medsnap/global/config/CryptoConfig.java
+++ b/src/main/java/backend/medsnap/global/config/CryptoConfig.java
@@ -1,10 +1,10 @@
 package backend.medsnap.global.config;
 
-import backend.medsnap.global.crypto.CryptoProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import backend.medsnap.global.crypto.CryptoProperties;
+
 @Configuration
 @EnableConfigurationProperties(CryptoProperties.class)
-public class CryptoConfig {
-}
+public class CryptoConfig {}

--- a/src/main/java/backend/medsnap/global/config/CryptoConfig.java
+++ b/src/main/java/backend/medsnap/global/config/CryptoConfig.java
@@ -1,0 +1,10 @@
+package backend.medsnap.global.config;
+
+import backend.medsnap.global.crypto.CryptoProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(CryptoProperties.class)
+public class CryptoConfig {
+}

--- a/src/main/java/backend/medsnap/global/config/SecurityConfig.java
+++ b/src/main/java/backend/medsnap/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package backend.medsnap.global.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,7 +14,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
@@ -34,7 +34,6 @@ public class SecurityConfig {
     @Value("${security.require-ssl}")
     private boolean requireSsl;
 
-    
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -51,18 +50,14 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(csrf -> csrf.disable())
-                .sessionManagement(sm -> sm
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        http.csrf(csrf -> csrf.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-        http
-                .formLogin((login) -> login.disable());
+        http.formLogin((login) -> login.disable());
 
         // HTTPS 강제 설정
         if (requireSsl) {
-            http
-                    .requiresChannel(channel -> channel.anyRequest().requiresSecure())
+            http.requiresChannel(channel -> channel.anyRequest().requiresSecure())
                     .headers(
                             headers ->
                                     headers.httpStrictTransportSecurity(
@@ -81,11 +76,11 @@ public class SecurityConfig {
         }
 
         // JWT 인증 필터 추가 (향후 구현 예정)
-        // http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        // http.addFilterBefore(jwtAuthenticationFilter,
+        // UsernamePasswordAuthenticationFilter.class);
 
         // 권한 설정
-        http
-                .authorizeHttpRequests(
+        http.authorizeHttpRequests(
                         authz -> {
                             if (swaggerAuthEnabled) {
                                 // 배포 환경: Swagger에 인증 필요
@@ -95,10 +90,7 @@ public class SecurityConfig {
                                                 "/swagger-ui/**",
                                                 "/swagger-ui.html")
                                         .hasRole("DOCS")
-                                        .requestMatchers(
-                                                "/api/v1/auth/**",
-                                                "/error",
-                                                "/error/**")
+                                        .requestMatchers("/api/v1/auth/**", "/error", "/error/**")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated();

--- a/src/main/java/backend/medsnap/global/crypto/AesGcmEncryptor.java
+++ b/src/main/java/backend/medsnap/global/crypto/AesGcmEncryptor.java
@@ -1,30 +1,31 @@
 package backend.medsnap.global.crypto;
 
-import backend.medsnap.domain.auth.exception.CryptoDecryptFailedException;
-import backend.medsnap.domain.auth.exception.CryptoEncryptFailedException;
-import org.springframework.stereotype.Component;
-
-import javax.crypto.Cipher;
-import javax.crypto.spec.GCMParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.SecureRandom;
 import java.util.Base64;
 
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.stereotype.Component;
+
+import backend.medsnap.domain.auth.exception.CryptoDecryptFailedException;
+import backend.medsnap.domain.auth.exception.CryptoEncryptFailedException;
+
 @Component
 public class AesGcmEncryptor {
 
     private final Key key;
-    private static final int GCM_IV_LENGTH = 12;  // 96 bits
+    private static final int GCM_IV_LENGTH = 12; // 96 bits
     private static final int GCM_TAG_LENGTH = 16; // 128 bits
 
     public AesGcmEncryptor(CryptoProperties properties) {
-        this.key = new SecretKeySpec(
-                properties.getAesSecretKey().getBytes(StandardCharsets.UTF_8),
-                "AES"
-        );
+        this.key =
+                new SecretKeySpec(
+                        properties.getAesSecretKey().getBytes(StandardCharsets.UTF_8), "AES");
     }
 
     public String encrypt(String plainText) {

--- a/src/main/java/backend/medsnap/global/crypto/AesGcmEncryptor.java
+++ b/src/main/java/backend/medsnap/global/crypto/AesGcmEncryptor.java
@@ -1,0 +1,72 @@
+package backend.medsnap.global.crypto;
+
+import backend.medsnap.domain.auth.exception.CryptoDecryptFailedException;
+import backend.medsnap.domain.auth.exception.CryptoEncryptFailedException;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class AesGcmEncryptor {
+
+    private final Key key;
+    private static final int GCM_IV_LENGTH = 12;  // 96 bits
+    private static final int GCM_TAG_LENGTH = 16; // 128 bits
+
+    public AesGcmEncryptor(CryptoProperties properties) {
+        this.key = new SecretKeySpec(
+                properties.getAesSecretKey().getBytes(StandardCharsets.UTF_8),
+                "AES"
+        );
+    }
+
+    public String encrypt(String plainText) {
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            new SecureRandom().nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, iv);
+            cipher.init(Cipher.ENCRYPT_MODE, key, spec);
+
+            byte[] ciphertext = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+
+            ByteBuffer buf = ByteBuffer.allocate(iv.length + ciphertext.length);
+            buf.put(iv);
+            buf.put(ciphertext);
+
+            return Base64.getEncoder().encodeToString(buf.array());
+        } catch (Exception e) {
+            throw new CryptoEncryptFailedException();
+        }
+    }
+
+    public String decrypt(String encryptedText) {
+        try {
+            byte[] data = Base64.getDecoder().decode(encryptedText);
+            ByteBuffer buf = ByteBuffer.wrap(data);
+
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            buf.get(iv);
+
+            byte[] ciphertext = new byte[buf.remaining()];
+            buf.get(ciphertext);
+
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, iv);
+            cipher.init(Cipher.DECRYPT_MODE, key, spec);
+
+            byte[] plain = cipher.doFinal(ciphertext);
+            return new String(plain, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new CryptoDecryptFailedException();
+        }
+    }
+}

--- a/src/main/java/backend/medsnap/global/crypto/CryptoProperties.java
+++ b/src/main/java/backend/medsnap/global/crypto/CryptoProperties.java
@@ -2,7 +2,6 @@ package backend.medsnap.global.crypto;
 
 import backend.medsnap.domain.auth.exception.CryptoKeyInvalidException;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "app.crypto")
 public class CryptoProperties {
@@ -13,7 +12,6 @@ public class CryptoProperties {
         return aesSecretKey;
     }
 
-    @ConstructorBinding
     public CryptoProperties(String aesSecretKey) {
         if (aesSecretKey == null || aesSecretKey.length() != 32) {
             throw new CryptoKeyInvalidException();

--- a/src/main/java/backend/medsnap/global/crypto/CryptoProperties.java
+++ b/src/main/java/backend/medsnap/global/crypto/CryptoProperties.java
@@ -1,7 +1,8 @@
 package backend.medsnap.global.crypto;
 
-import backend.medsnap.domain.auth.exception.CryptoKeyInvalidException;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import backend.medsnap.domain.auth.exception.CryptoKeyInvalidException;
 
 @ConfigurationProperties(prefix = "app.crypto")
 public class CryptoProperties {

--- a/src/main/java/backend/medsnap/global/crypto/CryptoProperties.java
+++ b/src/main/java/backend/medsnap/global/crypto/CryptoProperties.java
@@ -1,0 +1,23 @@
+package backend.medsnap.global.crypto;
+
+import backend.medsnap.domain.auth.exception.CryptoKeyInvalidException;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
+
+@ConfigurationProperties(prefix = "app.crypto")
+public class CryptoProperties {
+
+    private String aesSecretKey;
+
+    public String getAesSecretKey() {
+        return aesSecretKey;
+    }
+
+    @ConstructorBinding
+    public CryptoProperties(String aesSecretKey) {
+        if (aesSecretKey == null || aesSecretKey.length() != 32) {
+            throw new CryptoKeyInvalidException();
+        }
+        this.aesSecretKey = aesSecretKey;
+    }
+}

--- a/src/main/java/backend/medsnap/global/exception/ErrorCode.java
+++ b/src/main/java/backend/medsnap/global/exception/ErrorCode.java
@@ -26,7 +26,10 @@ public enum ErrorCode {
     // Authentication
     AUTH_OIDC_INVALID(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 아이디 토큰입니다."),
     AUTH_SOCIAL_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "A002", "가입되지 않은 소셜 계정입니다."),
-    AUTH_SOCIAL_ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "A003", "이미 가입된 소셜 계정입니다.");
+    AUTH_SOCIAL_ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "A003", "이미 가입된 소셜 계정입니다."),
+    AUTH_CRYPTO_KEY_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "A004", "암호화 키 설정이 잘못되었습니다."),
+    AUTH_CRYPTO_ENCRYPT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "A005", "데이터 암호화에 실패했습니다."),
+    AUTH_CRYPTO_DECRYPT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "A006", "데이터 복호화에 실패했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/backend/medsnap/infra/oauth/discovery/OidcDiscoveryClient.java
+++ b/src/main/java/backend/medsnap/infra/oauth/discovery/OidcDiscoveryClient.java
@@ -12,7 +12,7 @@ public class OidcDiscoveryClient {
         // 타임아웃
         SimpleClientHttpRequestFactory f = new SimpleClientHttpRequestFactory();
         f.setConnectTimeout(3000); // 연결 대기 3초
-        f.setReadTimeout(3000);    // 응답 대기 3초
+        f.setReadTimeout(3000); // 응답 대기 3초
 
         RestTemplate rt = new RestTemplate(f);
         return rt.getForObject(discoveryUrl, OidcDiscoveryProperties.class);

--- a/src/main/java/backend/medsnap/infra/oauth/discovery/OidcDiscoveryProperties.java
+++ b/src/main/java/backend/medsnap/infra/oauth/discovery/OidcDiscoveryProperties.java
@@ -1,8 +1,8 @@
 package backend.medsnap.infra.oauth.discovery;
 
-import lombok.Getter;
-
 import java.util.List;
+
+import lombok.Getter;
 
 @Getter
 public class OidcDiscoveryProperties {

--- a/src/main/java/backend/medsnap/infra/oauth/verifier/AbstractOidcVerifier.java
+++ b/src/main/java/backend/medsnap/infra/oauth/verifier/AbstractOidcVerifier.java
@@ -1,6 +1,9 @@
 package backend.medsnap.infra.oauth.verifier;
 
-import backend.medsnap.infra.oauth.exception.OidcVerificationException;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Objects;
+
 import com.auth0.jwk.JwkProvider;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -8,17 +11,16 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.JWTVerifier;
 
-import java.security.PublicKey;
-import java.security.interfaces.RSAPublicKey;
-import java.util.Objects;
+import backend.medsnap.infra.oauth.exception.OidcVerificationException;
 
 public abstract class AbstractOidcVerifier {
 
     protected abstract String[] getIssuers();
+
     protected abstract JwkProvider getJwkProvider();
 
     protected String[] getAllowedAlgs() {
-        return new String[]{"RS256"};
+        return new String[] {"RS256"};
     }
 
     protected final String[] clientId;
@@ -59,10 +61,11 @@ public abstract class AbstractOidcVerifier {
 
             // 1차 검증: 서명 + issuer
             Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) pk, null);
-            JWTVerifier verifier = JWT.require(algorithm)
-                    .withIssuer(getIssuers())
-                    .acceptLeeway(60) //  서버 간 시계 오차 허용 (초)
-                    .build();
+            JWTVerifier verifier =
+                    JWT.require(algorithm)
+                            .withIssuer(getIssuers())
+                            .acceptLeeway(60) //  서버 간 시계 오차 허용 (초)
+                            .build();
 
             DecodedJWT verified = verifier.verify(idToken);
 
@@ -71,8 +74,11 @@ public abstract class AbstractOidcVerifier {
             boolean audienceOk = false;
             for (String aud : audList) {
                 for (String allowedClient : clientId) {
-                    if (allowedClient != null && !allowedClient.isBlank() && allowedClient.equals(aud)) {
-                        audienceOk = true; break;
+                    if (allowedClient != null
+                            && !allowedClient.isBlank()
+                            && allowedClient.equals(aud)) {
+                        audienceOk = true;
+                        break;
                     }
                 }
                 if (audienceOk) break;
@@ -86,8 +92,11 @@ public abstract class AbstractOidcVerifier {
             if (azp != null && !azp.isBlank()) {
                 boolean azpOk = false;
                 for (String allowedClient : clientId) {
-                    if (allowedClient != null && !allowedClient.isBlank() && allowedClient.equals(azp)) {
-                        azpOk = true; break;
+                    if (allowedClient != null
+                            && !allowedClient.isBlank()
+                            && allowedClient.equals(azp)) {
+                        azpOk = true;
+                        break;
                     }
                 }
                 if (!azpOk) {

--- a/src/main/java/backend/medsnap/infra/oauth/verifier/AppleOidcVerifier.java
+++ b/src/main/java/backend/medsnap/infra/oauth/verifier/AppleOidcVerifier.java
@@ -1,0 +1,63 @@
+package backend.medsnap.infra.oauth.verifier;
+
+import backend.medsnap.infra.oauth.discovery.OidcDiscoveryClient;
+import backend.medsnap.infra.oauth.discovery.OidcDiscoveryProperties;
+import backend.medsnap.infra.oauth.exception.JwkProviderInitializationException;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Component("appleOidcVerifier")
+public class AppleOidcVerifier extends AbstractOidcVerifier {
+
+    private final String[] issuers;
+    private final String[] allowedAlgs;
+    private final JwkProvider jwkProvider;
+
+    public AppleOidcVerifier(
+            @Value("${apple.service-id:}") String clientId,
+            OidcDiscoveryClient discoveryClient
+    ) {
+        super(new String[]{clientId});
+
+        String discoveryUrl = "https://appleid.apple.com/.well-known/openid-configuration";
+        OidcDiscoveryProperties props = discoveryClient.fetch(discoveryUrl);
+
+        this.issuers = new String[] {props.getIssuer()};
+
+        List<String> algs = props.getId_token_signing_alg_values_supported();
+        this.allowedAlgs = (algs == null || algs.isEmpty())
+                ? new String[] { "RS256" }
+                : algs.toArray(new String[0]);
+
+        try {
+            this.jwkProvider = new JwkProviderBuilder(new URL(props.getJwks_uri()))
+                    .cached(10, 1, TimeUnit.HOURS)
+                    .rateLimited(10, 1, TimeUnit.MINUTES)
+                    .build();
+        } catch (Exception e) {
+            throw new JwkProviderInitializationException(e);
+        }
+    }
+
+    @Override
+    protected String[] getIssuers() {
+        return issuers;
+    }
+
+    @Override
+    protected JwkProvider getJwkProvider() {
+        return jwkProvider;
+    }
+
+    @Override
+    protected String[] getAllowedAlgs() {
+        return allowedAlgs;
+    }
+
+}

--- a/src/main/java/backend/medsnap/infra/oauth/verifier/AppleOidcVerifier.java
+++ b/src/main/java/backend/medsnap/infra/oauth/verifier/AppleOidcVerifier.java
@@ -24,6 +24,9 @@ public class AppleOidcVerifier extends AbstractOidcVerifier {
             OidcDiscoveryClient discoveryClient
     ) {
         super(new String[]{clientId});
+        if (clientId == null || clientId.isBlank()) {
+            throw new IllegalStateException("kakao.client-id가 설정되지 않았습니다.");
+        }
 
         String discoveryUrl = "https://appleid.apple.com/.well-known/openid-configuration";
         OidcDiscoveryProperties props = discoveryClient.fetch(discoveryUrl);

--- a/src/main/java/backend/medsnap/infra/oauth/verifier/AppleOidcVerifier.java
+++ b/src/main/java/backend/medsnap/infra/oauth/verifier/AppleOidcVerifier.java
@@ -1,16 +1,18 @@
 package backend.medsnap.infra.oauth.verifier;
 
-import backend.medsnap.infra.oauth.discovery.OidcDiscoveryClient;
-import backend.medsnap.infra.oauth.discovery.OidcDiscoveryProperties;
-import backend.medsnap.infra.oauth.exception.JwkProviderInitializationException;
-import com.auth0.jwk.JwkProvider;
-import com.auth0.jwk.JwkProviderBuilder;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+
+import backend.medsnap.infra.oauth.discovery.OidcDiscoveryClient;
+import backend.medsnap.infra.oauth.discovery.OidcDiscoveryProperties;
+import backend.medsnap.infra.oauth.exception.JwkProviderInitializationException;
 
 @Component("appleOidcVerifier")
 public class AppleOidcVerifier extends AbstractOidcVerifier {
@@ -20,10 +22,8 @@ public class AppleOidcVerifier extends AbstractOidcVerifier {
     private final JwkProvider jwkProvider;
 
     public AppleOidcVerifier(
-            @Value("${apple.service-id:}") String clientId,
-            OidcDiscoveryClient discoveryClient
-    ) {
-        super(new String[]{clientId});
+            @Value("${apple.service-id:}") String clientId, OidcDiscoveryClient discoveryClient) {
+        super(new String[] {clientId});
         if (clientId == null || clientId.isBlank()) {
             throw new IllegalStateException("kakao.client-id가 설정되지 않았습니다.");
         }
@@ -34,15 +34,17 @@ public class AppleOidcVerifier extends AbstractOidcVerifier {
         this.issuers = new String[] {props.getIssuer()};
 
         List<String> algs = props.getId_token_signing_alg_values_supported();
-        this.allowedAlgs = (algs == null || algs.isEmpty())
-                ? new String[] { "RS256" }
-                : algs.toArray(new String[0]);
+        this.allowedAlgs =
+                (algs == null || algs.isEmpty())
+                        ? new String[] {"RS256"}
+                        : algs.toArray(new String[0]);
 
         try {
-            this.jwkProvider = new JwkProviderBuilder(new URL(props.getJwks_uri()))
-                    .cached(10, 1, TimeUnit.HOURS)
-                    .rateLimited(10, 1, TimeUnit.MINUTES)
-                    .build();
+            this.jwkProvider =
+                    new JwkProviderBuilder(new URL(props.getJwks_uri()))
+                            .cached(10, 1, TimeUnit.HOURS)
+                            .rateLimited(10, 1, TimeUnit.MINUTES)
+                            .build();
         } catch (Exception e) {
             throw new JwkProviderInitializationException(e);
         }
@@ -62,5 +64,4 @@ public class AppleOidcVerifier extends AbstractOidcVerifier {
     protected String[] getAllowedAlgs() {
         return allowedAlgs;
     }
-
 }

--- a/src/main/java/backend/medsnap/infra/oauth/verifier/GoogleOidcVerifier.java
+++ b/src/main/java/backend/medsnap/infra/oauth/verifier/GoogleOidcVerifier.java
@@ -26,6 +26,15 @@ public class GoogleOidcVerifier extends AbstractOidcVerifier {
             OidcDiscoveryClient discoveryClient
     ) {
         super(new String[]{iosClientId, androidClientId, clientId});
+        if (iosClientId == null || iosClientId.isBlank()) {
+            throw new IllegalStateException("google.ios.client-id가 설정되지 않았습니다.");
+        }
+        if (androidClientId == null || androidClientId.isBlank()) {
+            throw new IllegalStateException("google.android.client-id가 설정되지 않았습니다.");
+        }
+        if (clientId == null || clientId.isBlank()) {
+            throw new IllegalStateException("google.client-id가 설정되지 않았습니다.");
+        }
 
         // 디스커버리 조회
         String discoveryUrl = "https://accounts.google.com/.well-known/openid-configuration";

--- a/src/main/java/backend/medsnap/infra/oauth/verifier/GoogleOidcVerifier.java
+++ b/src/main/java/backend/medsnap/infra/oauth/verifier/GoogleOidcVerifier.java
@@ -1,16 +1,18 @@
 package backend.medsnap.infra.oauth.verifier;
 
-import backend.medsnap.infra.oauth.discovery.OidcDiscoveryClient;
-import backend.medsnap.infra.oauth.discovery.OidcDiscoveryProperties;
-import backend.medsnap.infra.oauth.exception.JwkProviderInitializationException;
-import com.auth0.jwk.JwkProvider;
-import com.auth0.jwk.JwkProviderBuilder;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+
+import backend.medsnap.infra.oauth.discovery.OidcDiscoveryClient;
+import backend.medsnap.infra.oauth.discovery.OidcDiscoveryProperties;
+import backend.medsnap.infra.oauth.exception.JwkProviderInitializationException;
 
 @Component("googleOidcVerifier")
 public class GoogleOidcVerifier extends AbstractOidcVerifier {
@@ -23,9 +25,8 @@ public class GoogleOidcVerifier extends AbstractOidcVerifier {
             @Value("${google.ios.client-id}") String iosClientId,
             @Value("${google.android.client-id}") String androidClientId,
             @Value("${google.client-id}") String clientId,
-            OidcDiscoveryClient discoveryClient
-    ) {
-        super(new String[]{iosClientId, androidClientId, clientId});
+            OidcDiscoveryClient discoveryClient) {
+        super(new String[] {iosClientId, androidClientId, clientId});
         if (iosClientId == null || iosClientId.isBlank()) {
             throw new IllegalStateException("google.ios.client-id가 설정되지 않았습니다.");
         }
@@ -41,20 +42,22 @@ public class GoogleOidcVerifier extends AbstractOidcVerifier {
         OidcDiscoveryProperties props = discoveryClient.fetch(discoveryUrl);
 
         // issuer
-        this.issuers = new String[] { props.getIssuer(), "accounts.google.com" };
+        this.issuers = new String[] {props.getIssuer(), "accounts.google.com"};
 
         // 허용 알고리즘 목록
         List<String> algs = props.getId_token_signing_alg_values_supported();
-        this.allowedAlgs = (algs == null || algs.isEmpty())
-                ? new String[] { "RS256" }
-                : algs.toArray(new String[0]);
+        this.allowedAlgs =
+                (algs == null || algs.isEmpty())
+                        ? new String[] {"RS256"}
+                        : algs.toArray(new String[0]);
 
         // JWK Provider 초기화
         try {
-            this.jwkProvider = new JwkProviderBuilder(new URL(props.getJwks_uri()))
-                    .cached(10, 1, TimeUnit.HOURS)
-                    .rateLimited(10, 1, TimeUnit.MINUTES)
-                    .build();
+            this.jwkProvider =
+                    new JwkProviderBuilder(new URL(props.getJwks_uri()))
+                            .cached(10, 1, TimeUnit.HOURS)
+                            .rateLimited(10, 1, TimeUnit.MINUTES)
+                            .build();
         } catch (Exception e) {
             throw new JwkProviderInitializationException(e);
         }

--- a/src/main/java/backend/medsnap/infra/oauth/verifier/KakaoOidcVerifier.java
+++ b/src/main/java/backend/medsnap/infra/oauth/verifier/KakaoOidcVerifier.java
@@ -1,16 +1,18 @@
 package backend.medsnap.infra.oauth.verifier;
 
-import backend.medsnap.infra.oauth.discovery.OidcDiscoveryClient;
-import backend.medsnap.infra.oauth.discovery.OidcDiscoveryProperties;
-import backend.medsnap.infra.oauth.exception.JwkProviderInitializationException;
-import com.auth0.jwk.JwkProvider;
-import com.auth0.jwk.JwkProviderBuilder;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+
+import backend.medsnap.infra.oauth.discovery.OidcDiscoveryClient;
+import backend.medsnap.infra.oauth.discovery.OidcDiscoveryProperties;
+import backend.medsnap.infra.oauth.exception.JwkProviderInitializationException;
 
 @Component("kakaoOidcVerifier")
 public class KakaoOidcVerifier extends AbstractOidcVerifier {
@@ -20,10 +22,8 @@ public class KakaoOidcVerifier extends AbstractOidcVerifier {
     private final JwkProvider jwkProvider;
 
     public KakaoOidcVerifier(
-            @Value("${kakao.client-id}") String clientId,
-            OidcDiscoveryClient discoveryClient
-    ) {
-        super(new String[]{clientId});
+            @Value("${kakao.client-id}") String clientId, OidcDiscoveryClient discoveryClient) {
+        super(new String[] {clientId});
         if (clientId == null || clientId.isBlank()) {
             throw new IllegalStateException("kakao.client-id가 설정되지 않았습니다.");
         }
@@ -31,18 +31,20 @@ public class KakaoOidcVerifier extends AbstractOidcVerifier {
         String discoveryUrl = "https://kauth.kakao.com/.well-known/openid-configuration";
         OidcDiscoveryProperties props = discoveryClient.fetch(discoveryUrl);
 
-        this.issuers = new String[]{ props.getIssuer() };
+        this.issuers = new String[] {props.getIssuer()};
 
         List<String> algs = props.getId_token_signing_alg_values_supported();
-        this.allowedAlgs = (algs == null || algs.isEmpty())
-                ? new String[] { "RS256" }
-                : algs.toArray(new String[0]);
+        this.allowedAlgs =
+                (algs == null || algs.isEmpty())
+                        ? new String[] {"RS256"}
+                        : algs.toArray(new String[0]);
 
         try {
-            this.jwkProvider = new JwkProviderBuilder(new URL(props.getJwks_uri()))
-                    .cached(10, 1, TimeUnit.HOURS)
-                    .rateLimited(10, 1, TimeUnit.MINUTES)
-                    .build();
+            this.jwkProvider =
+                    new JwkProviderBuilder(new URL(props.getJwks_uri()))
+                            .cached(10, 1, TimeUnit.HOURS)
+                            .rateLimited(10, 1, TimeUnit.MINUTES)
+                            .build();
         } catch (Exception e) {
             throw new JwkProviderInitializationException(e);
         }
@@ -62,5 +64,4 @@ public class KakaoOidcVerifier extends AbstractOidcVerifier {
     protected String[] getAllowedAlgs() {
         return allowedAlgs;
     }
-
 }

--- a/src/main/java/backend/medsnap/infra/oauth/verifier/KakaoOidcVerifier.java
+++ b/src/main/java/backend/medsnap/infra/oauth/verifier/KakaoOidcVerifier.java
@@ -24,6 +24,9 @@ public class KakaoOidcVerifier extends AbstractOidcVerifier {
             OidcDiscoveryClient discoveryClient
     ) {
         super(new String[]{clientId});
+        if (clientId == null || clientId.isBlank()) {
+            throw new IllegalStateException("kakao.client-id가 설정되지 않았습니다.");
+        }
 
         String discoveryUrl = "https://kauth.kakao.com/.well-known/openid-configuration";
         OidcDiscoveryProperties props = discoveryClient.fetch(discoveryUrl);

--- a/src/main/java/backend/medsnap/infra/oauth/verifier/NaverOidcVerifier.java
+++ b/src/main/java/backend/medsnap/infra/oauth/verifier/NaverOidcVerifier.java
@@ -19,6 +19,9 @@ public class NaverOidcVerifier extends AbstractOidcVerifier {
 
     public NaverOidcVerifier(@Value("${naver.client-id}") String clientId) {
         super(new String[]{clientId});
+        if (clientId == null || clientId.isBlank()) {
+            throw new IllegalStateException("naver.client-id가 설정되지 않았습니다.");
+        }
         try {
             this.jwkProvider = new JwkProviderBuilder(new URL(JWKS_URL))
                     .cached(10, 1, TimeUnit.HOURS)

--- a/src/main/java/backend/medsnap/infra/oauth/verifier/NaverOidcVerifier.java
+++ b/src/main/java/backend/medsnap/infra/oauth/verifier/NaverOidcVerifier.java
@@ -1,32 +1,35 @@
 package backend.medsnap.infra.oauth.verifier;
 
-import backend.medsnap.infra.oauth.exception.JwkProviderInitializationException;
-import com.auth0.jwk.JwkProvider;
-import com.auth0.jwk.JwkProviderBuilder;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.net.URL;
-import java.util.concurrent.TimeUnit;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+
+import backend.medsnap.infra.oauth.exception.JwkProviderInitializationException;
 
 @Component("naverOidcVerifier")
 public class NaverOidcVerifier extends AbstractOidcVerifier {
 
-    private static final String[] ISSUERS = { "https://nid.naver.com" };
+    private static final String[] ISSUERS = {"https://nid.naver.com"};
     private static final String JWKS_URL = "https://nid.naver.com/oauth2/jwks";
 
     private final JwkProvider jwkProvider;
 
     public NaverOidcVerifier(@Value("${naver.client-id}") String clientId) {
-        super(new String[]{clientId});
+        super(new String[] {clientId});
         if (clientId == null || clientId.isBlank()) {
             throw new IllegalStateException("naver.client-id가 설정되지 않았습니다.");
         }
         try {
-            this.jwkProvider = new JwkProviderBuilder(new URL(JWKS_URL))
-                    .cached(10, 1, TimeUnit.HOURS)
-                    .rateLimited(10, 1, TimeUnit.MINUTES)
-                    .build();
+            this.jwkProvider =
+                    new JwkProviderBuilder(new URL(JWKS_URL))
+                            .cached(10, 1, TimeUnit.HOURS)
+                            .rateLimited(10, 1, TimeUnit.MINUTES)
+                            .build();
         } catch (Exception e) {
             throw new JwkProviderInitializationException(e);
         }
@@ -44,6 +47,6 @@ public class NaverOidcVerifier extends AbstractOidcVerifier {
 
     @Override
     protected String[] getAllowedAlgs() {
-        return new String[] { "RS256" };
+        return new String[] {"RS256"};
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,6 +46,9 @@ google.ios.client-id=${GOOGLE_IOS_CLIENT_ID}
 google.android.client-id=${GOOGLE_ANDROID_CLIENT_ID}
 google.client-id=${GOOGLE_CLIENT_ID}
 
+# APPLE OIDC
+apple.service-id=${APPLE_SERVICE_ID}
+
 jwt.access-token-validity-hours=1
 jwt.refresh-token-validity-days=7
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,6 +54,7 @@ jwt.refresh-token-validity-days=7
 
 jwt.secret=${JWT_SECRET}
 jwt.issuer=${JWT_ISSUER}
+app.crypto.aes-secret-key=${APP_CRYPTO_AES_SECRET_KEY}
 
 # PostgreSQL Database Configuration
 spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}


### PR DESCRIPTION
## 📖개요
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #26 
<br>
<br>

## 💻작업사항

- 애플 로그인 구현 <br>

## 💡작성한 이슈 외에 작업한 사항

- refresh token 암호화 <br>

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - Apple 계정 로그인(Apple OIDC) 지원을 추가하고 소셜 제공자에 Apple을 포함했습니다.
- 리팩터링
  - 서버에 저장되는 리프레시 토큰을 암호화하도록 인증 흐름을 변경했습니다.
- 잡무
  - 암호화 구성 항목 및 Apple 서비스 ID 설정을 추가했습니다.
  - 암호화 관련 예외·오류코드를 확장하고 구성값 검증을 도입했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->