### PR TITLE
feat: 약 정보 수정 api

### DIFF
--- a/src/main/java/backend/medsnap/domain/alarm/dto/request/AlarmDeleteRequest.java
+++ b/src/main/java/backend/medsnap/domain/alarm/dto/request/AlarmDeleteRequest.java
@@ -6,11 +6,13 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class AlarmDeleteRequest {
 
     @NotNull(message = "삭제할 알람 ID 목록은 필수입니다.")

--- a/src/main/java/backend/medsnap/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/backend/medsnap/domain/alarm/repository/AlarmRepository.java
@@ -26,4 +26,9 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     @Query("SELECT a.id FROM Alarm a WHERE a.id IN :alarmIds AND a.medication.id = :medicationId")
     List<Long> findExistingAlarmIds(
             @Param("alarmIds") List<Long> alarmIds, @Param("medicationId") Long medicationId);
+
+    /** 특정 약에 연결된 모든 알람 삭제 */
+    @Modifying
+    @Query("DELETE FROM Alarm a WHERE a.medication.id = :medicationId")
+    void deleteByMedicationId(@Param("medicationId") Long medicationId);
 }

--- a/src/main/java/backend/medsnap/domain/alarm/service/AlarmService.java
+++ b/src/main/java/backend/medsnap/domain/alarm/service/AlarmService.java
@@ -79,4 +79,18 @@ public class AlarmService {
             log.info("약 ID: {}의 {}개 알람이 삭제되었습니다.", medication.getId(), deletedCount);
         }
     }
+
+    /** 특정 약의 전체 알람 삭제 */
+    @Transactional
+    public void deleteAllAlarmsByMedicationId(Long medicationId) {
+
+        alarmRepository.deleteByMedicationId(medicationId);
+        log.info("약 ID: {}에 연결된 모든 알람이 삭제되었습니다.", medicationId);
+    }
+
+    /** 특정 약의 남은 알람 개수 조회 */
+    @Transactional(readOnly = true)
+    public int getRemainingAlarmCount(Long medicationId) {
+        return alarmRepository.countByMedicationId(medicationId);
+    }
 }

--- a/src/main/java/backend/medsnap/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/backend/medsnap/domain/auth/dto/request/LoginRequest.java
@@ -4,9 +4,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import backend.medsnap.domain.user.entity.Provider;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class LoginRequest {
 
     @NotBlank(message = "idToken은 필수입니다.")

--- a/src/main/java/backend/medsnap/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/backend/medsnap/domain/auth/dto/request/SignupRequest.java
@@ -5,12 +5,12 @@ import java.time.LocalDate;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import backend.medsnap.domain.user.entity.Provider;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/backend/medsnap/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/backend/medsnap/domain/auth/dto/request/SignupRequest.java
@@ -5,12 +5,16 @@ import java.time.LocalDate;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import backend.medsnap.domain.user.entity.Provider;
 import lombok.Getter;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class SignupRequest {
 
     @NotBlank(message = "Id Token은 필수입니다.")

--- a/src/main/java/backend/medsnap/domain/faq/dto/request/FaqRequest.java
+++ b/src/main/java/backend/medsnap/domain/faq/dto/request/FaqRequest.java
@@ -4,11 +4,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import backend.medsnap.domain.faq.entity.FaqCategory;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class FaqRequest {
 
     @NotBlank(message = "질문은 필수입니다.")

--- a/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
+++ b/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
@@ -1,5 +1,6 @@
 package backend.medsnap.domain.medication.controller;
 
+import backend.medsnap.domain.medication.dto.request.MedicationUpdateRequest;
 import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,19 @@ public class MedicationController implements MedicationSwagger {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(HttpStatus.CREATED, response));
+    }
+
+    @Override
+    @PutMapping(value = "/{medicationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<MedicationResponse>> updateMedication(
+            @PathVariable Long medicationId,
+            @RequestPart("request") @Valid MedicationUpdateRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile image) {
+
+        MedicationResponse response = medicationService.updateMedication(medicationId, request, image);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(response));
     }
 
     @Override

--- a/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
+++ b/src/main/java/backend/medsnap/domain/medication/controller/MedicationController.java
@@ -1,6 +1,5 @@
 package backend.medsnap.domain.medication.controller;
 
-import backend.medsnap.domain.medication.dto.request.MedicationUpdateRequest;
 import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
@@ -11,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import backend.medsnap.domain.alarm.dto.request.AlarmDeleteRequest;
 import backend.medsnap.domain.medication.dto.request.MedicationCreateRequest;
+import backend.medsnap.domain.medication.dto.request.MedicationUpdateRequest;
 import backend.medsnap.domain.medication.dto.response.MedicationResponse;
 import backend.medsnap.domain.medication.service.MedicationService;
 import backend.medsnap.global.dto.ApiResponse;
@@ -42,10 +42,10 @@ public class MedicationController implements MedicationSwagger {
             @RequestPart("request") @Valid MedicationUpdateRequest request,
             @RequestPart(value = "image", required = false) MultipartFile image) {
 
-        MedicationResponse response = medicationService.updateMedication(medicationId, request, image);
+        MedicationResponse response =
+                medicationService.updateMedication(medicationId, request, image);
 
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.success(response));
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
     }
 
     @Override

--- a/src/main/java/backend/medsnap/domain/medication/controller/MedicationSwagger.java
+++ b/src/main/java/backend/medsnap/domain/medication/controller/MedicationSwagger.java
@@ -10,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import backend.medsnap.domain.alarm.dto.request.AlarmDeleteRequest;
 import backend.medsnap.domain.medication.dto.request.MedicationCreateRequest;
+import backend.medsnap.domain.medication.dto.request.MedicationUpdateRequest;
 import backend.medsnap.domain.medication.dto.response.MedicationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -133,6 +134,145 @@ public interface MedicationSwagger {
                     @Valid
                     MedicationCreateRequest request,
             @Parameter(description = "약 이미지 파일", required = true) @RequestPart("image")
+                    MultipartFile image);
+
+    @Operation(summary = "약 정보 수정", description = "기존 약의 정보를 수정합니다. 이미지는 선택사항입니다.")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "약 수정 요청 (multipart/form-data)",
+            content = @Content(mediaType = "multipart/form-data"))
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "약 수정 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                backend.medsnap.global.dto
+                                                                        .ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                        {
+                          "code": "SUCCESS",
+                          "httpStatus": 200,
+                          "message": "요청이 성공적으로 처리되었습니다.",
+                          "data": {
+                            "id": 1,
+                            "name": "수정된 타이레놀",
+                            "imageUrl": "https://s3.amazonaws.com/bucket/medications/new_uuid_timestamp.jpg",
+                            "notifyCaregiver": false,
+                            "preNotify": true,
+                            "doseTimes": ["08:00", "20:00"],
+                            "doseDays": ["MON", "TUE", "WED", "THU", "FRI"],
+                            "createdAt": "2024-01-01T10:00:00",
+                            "updatedAt": "2024-01-02T15:30:00"
+                          }
+                        }
+                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "입력값 검증 실패",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                backend.medsnap.global.dto
+                                                                        .ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                        {
+                          "code": "C002",
+                          "httpStatus": 400,
+                          "message": "입력값 검증에 실패했습니다.",
+                          "data": null
+                        }
+                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "약을 찾을 수 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                backend.medsnap.global.dto
+                                                                        .ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                        {
+                          "code": "M001",
+                          "httpStatus": 404,
+                          "message": "약 정보를 찾을 수 없습니다.",
+                          "data": null
+                        }
+                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "409",
+                        description = "중복된 약 이름",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                backend.medsnap.global.dto
+                                                                        .ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                        {
+                          "code": "M002",
+                          "httpStatus": 409,
+                          "message": "이미 등록된 약 이름입니다.",
+                          "data": null
+                        }
+                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "500",
+                        description = "서버 오류",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                backend.medsnap.global.dto
+                                                                        .ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                        {
+                          "code": "C001",
+                          "httpStatus": 500,
+                          "message": "내부 서버 오류가 발생했습니다.",
+                          "data": null
+                        }
+                        """)))
+            })
+    ResponseEntity<backend.medsnap.global.dto.ApiResponse<MedicationResponse>> updateMedication(
+            @Parameter(description = "수정할 약의 ID", required = true, example = "1")
+                    @PathVariable("medicationId")
+                    Long medicationId,
+            @Parameter(description = "약 수정 JSON 데이터", required = true)
+                    @RequestPart("request")
+                    @Valid
+                    MedicationUpdateRequest request,
+            @Parameter(description = "약 이미지 파일 (선택사항)")
+                    @RequestPart(value = "image", required = false)
                     MultipartFile image);
 
     @Operation(summary = "약 삭제", description = "등록된 약과 관련된 모든 알람을 삭제합니다.")

--- a/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationCreateRequest.java
+++ b/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationCreateRequest.java
@@ -8,11 +8,13 @@ import jakarta.validation.constraints.NotNull;
 
 import backend.medsnap.domain.alarm.entity.DayOfWeek;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @Schema(
         description = "약 등록 요청",
         example =

--- a/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationUpdateRequest.java
+++ b/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationUpdateRequest.java
@@ -1,0 +1,51 @@
+package backend.medsnap.domain.medication.dto.request;
+
+import backend.medsnap.domain.alarm.entity.DayOfWeek;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "약 정보 수정 요청",
+        example =
+                """
+    {
+      "name": "타이레놀",
+      "notifyCaregiver": true,
+      "preNotify": true,
+      "doseTimes": ["09:00","21:00"],
+      "doseDays": [
+        "MON",
+        "TUE",
+        "WED"
+      ]
+    }
+    """)
+public class MedicationUpdateRequest {
+
+    @Schema(description = "약 이름")
+    @NotBlank(message = "약 이름은 필수입니다")
+    private String name;
+
+    @Schema(description = "보호자 알림 여부")
+    @NotNull(message = "보호자 알림 여부는 필수입니다")
+    private Boolean notifyCaregiver;
+
+    @Schema(description = "사전 알림 여부")
+    @NotNull(message = "사전 알림 여부는 필수입니다")
+    private Boolean preNotify;
+
+    @Schema(description = "복용 시간 목록 (HH:mm)")
+    @NotEmpty(message = "복용 시간은 최소 1개 이상이어야 합니다")
+    private List<String> doseTimes;
+
+    @Schema(description = "복용 요일 목록")
+    @NotEmpty(message = "복용 요일은 최소 1개 이상이어야 합니다")
+    private List<DayOfWeek> doseDays;
+}

--- a/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationUpdateRequest.java
+++ b/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationUpdateRequest.java
@@ -1,18 +1,20 @@
 package backend.medsnap.domain.medication.dto.request;
 
-import backend.medsnap.domain.alarm.entity.DayOfWeek;
-import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+
+import backend.medsnap.domain.alarm.entity.DayOfWeek;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
 @Builder
-@Schema(description = "약 정보 수정 요청",
+@Schema(
+        description = "약 정보 수정 요청",
         example =
                 """
     {

--- a/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationUpdateRequest.java
+++ b/src/main/java/backend/medsnap/domain/medication/dto/request/MedicationUpdateRequest.java
@@ -8,11 +8,13 @@ import jakarta.validation.constraints.NotNull;
 
 import backend.medsnap.domain.alarm.entity.DayOfWeek;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Schema(
         description = "약 정보 수정 요청",
         example =

--- a/src/main/java/backend/medsnap/domain/medication/entity/Medication.java
+++ b/src/main/java/backend/medsnap/domain/medication/entity/Medication.java
@@ -48,4 +48,12 @@ public class Medication extends BaseEntity {
         this.notifyCaregiver = notifyCaregiver;
         this.preNotify = preNotify;
     }
+
+    public void updateMedicationDetails(
+            String name, String imageUrl, Boolean notifyCaregiver, Boolean preNotify) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.notifyCaregiver = notifyCaregiver;
+        this.preNotify = preNotify;
+    }
 }

--- a/src/main/java/backend/medsnap/domain/medication/repository/MedicationRepository.java
+++ b/src/main/java/backend/medsnap/domain/medication/repository/MedicationRepository.java
@@ -10,4 +10,7 @@ public interface MedicationRepository extends JpaRepository<Medication, Long> {
 
     /** 약 이름 중복 체크 */
     boolean existsByName(String name);
+
+    /** 특정 ID를 제외한 약 이름 중복 체크 */
+    boolean existsByNameAndIdNot(String name, Long id);
 }

--- a/src/main/java/backend/medsnap/domain/medication/service/MedicationService.java
+++ b/src/main/java/backend/medsnap/domain/medication/service/MedicationService.java
@@ -2,7 +2,6 @@ package backend.medsnap.domain.medication.service;
 
 import java.util.List;
 
-import backend.medsnap.domain.medication.dto.request.MedicationUpdateRequest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +11,7 @@ import backend.medsnap.domain.alarm.entity.Alarm;
 import backend.medsnap.domain.alarm.repository.AlarmRepository;
 import backend.medsnap.domain.alarm.service.AlarmService;
 import backend.medsnap.domain.medication.dto.request.MedicationCreateRequest;
+import backend.medsnap.domain.medication.dto.request.MedicationUpdateRequest;
 import backend.medsnap.domain.medication.dto.response.MedicationResponse;
 import backend.medsnap.domain.medication.entity.Medication;
 import backend.medsnap.domain.medication.exception.InvalidMedicationDataException;
@@ -132,7 +132,7 @@ public class MedicationService {
         int alarmCount = medication.getAlarms().size();
         log.info("약 ID: {}에 연결된 알람 개수: {}", medicationId, alarmCount);
 
-        // 약 삭제 (cascade로 알람도 함께 삭제됨)
+        // 약 삭제
         medicationRepository.delete(medication);
         log.info("약 ID: {} 및 관련 알람 {}개가 삭제되었습니다.", medicationId, alarmCount);
 


### PR DESCRIPTION
## 📖개요
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #29 
<br>
<br>

## 💻작업사항

- 약 정보 수정 api 구현<br>

## 💡작성한 이슈 외에 작업한 사항

- 엔티티 반환값 통일 <br>

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신규 기능
  * 약 정보 수정 엔드포인트 추가: 이름, 보호자 알림/사전알림, 복용 시간·요일, 이미지 동시 업데이트(멀티파트 지원).
  * 알람 일괄 삭제 및 남은 알람 수 조회 기능 추가.
  * 약 이름 중복 검사(업데이트용) 지원 및 이미지 업로드/롤백 처리 개선.
* 버그 수정
  * 업데이트 중 약 이름 중복 처리 안정화(중복시 롤백 처리).
* 문서
  * 업데이트 엔드포인트에 대한 Swagger/OpenAPI 문서 및 응답 예시 추가.
* 기타
  * 업데이트 요청 DTO 및 여러 요청 DTO에 생성자/검증 어노테이션 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->