### PR TITLE
[Feat/#45]: 유저 정보 조회

### DIFF
--- a/src/main/java/backend/medsnap/domain/user/controller/UserController.java
+++ b/src/main/java/backend/medsnap/domain/user/controller/UserController.java
@@ -1,13 +1,11 @@
 package backend.medsnap.domain.user.controller;
 
+import backend.medsnap.domain.user.dto.response.UserInfoResponse;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import backend.medsnap.domain.auth.dto.token.CustomUserDetails;
 import backend.medsnap.domain.user.dto.request.MyPageUpdateRequest;
@@ -22,6 +20,15 @@ import lombok.RequiredArgsConstructor;
 public class UserController implements UserSwagger {
 
     private final UserService userService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getUserInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(
+                ApiResponse.success(userService.getUserInfo(userDetails.getId()))
+        );
+    }
 
     @Override
     @PutMapping("/mypage")

--- a/src/main/java/backend/medsnap/domain/user/controller/UserSwagger.java
+++ b/src/main/java/backend/medsnap/domain/user/controller/UserSwagger.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import backend.medsnap.domain.auth.dto.token.CustomUserDetails;
 import backend.medsnap.domain.user.dto.request.MyPageUpdateRequest;
 import backend.medsnap.domain.user.dto.response.MyPageResponse;
+import backend.medsnap.domain.user.dto.response.UserInfoResponse;
 import backend.medsnap.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -20,6 +21,78 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "users", description = "사용자 API")
 public interface UserSwagger {
+
+    @Operation(
+            summary = "사용자 정보 조회",
+            description = "현재 로그인한 사용자의 기본 정보를 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "사용자 정보 조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                            {
+                                              "code": "SUCCESS",
+                                              "httpStatus": 200,
+                                              "message": "요청이 성공적으로 처리되었습니다.",
+                                              "data": {
+                                                "id": 1,
+                                                "role": "PATIENT",
+                                                "name": "홍길동",
+                                                "provider": "KAKAO"
+                                              },
+                                              "error": null
+                                            }
+                                            """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "401",
+                        description = "인증이 필요합니다",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                            {
+                                              "code": "A008",
+                                              "httpStatus": 401,
+                                              "message": "인증이 필요합니다.",
+                                              "data": null,
+                                              "error": null
+                                            }
+                                            """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "사용자를 찾을 수 없습니다",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                            {
+                                              "code": "U001",
+                                              "httpStatus": 404,
+                                              "message": "사용자를 찾을 수 없습니다.",
+                                              "data": null,
+                                              "error": null
+                                            }
+                                            """)))
+            })
+    ResponseEntity<ApiResponse<UserInfoResponse>> getUserInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails);
 
     @Operation(
             summary = "마이페이지 수정",

--- a/src/main/java/backend/medsnap/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/backend/medsnap/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,16 @@
+package backend.medsnap.domain.user.dto.response;
+
+import backend.medsnap.domain.user.entity.Provider;
+import backend.medsnap.domain.user.entity.Role;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfoResponse {
+
+    private Long id;
+    private Role role;
+    private String name;
+    private Provider provider;
+}

--- a/src/main/java/backend/medsnap/domain/user/service/UserService.java
+++ b/src/main/java/backend/medsnap/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package backend.medsnap.domain.user.service;
 
+import backend.medsnap.domain.user.dto.response.UserInfoResponse;
+import backend.medsnap.domain.user.entity.SocialAccount;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +19,26 @@ import lombok.extern.slf4j.Slf4j;
 public class UserService {
 
     private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public UserInfoResponse getUserInfo(Long userId) {
+
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new UserNotFoundException(userId));
+
+        SocialAccount socialAccount = user.getSocialAccounts().stream()
+                .findFirst()
+                .orElse(null);
+
+        return UserInfoResponse.builder()
+                .id(user.getId())
+                .role(user.getRole())
+                .name(user.getName())
+                .provider(socialAccount != null ? socialAccount.getProvider() : null)
+                .build();
+    }
 
     @Transactional
     public MyPageResponse updateMyPage(Long userId, MyPageUpdateRequest request) {


### PR DESCRIPTION
## 📖개요
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #45 
<br>
<br>

## 💻작업사항

- <br>

## 💡작성한 이슈 외에 작업한 사항

- <br>

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 인증된 사용자의 기본 정보(id, role, name, provider)를 반환하는 사용자 정보 조회 API 추가.
  - 경로: GET /api/v1/users (인증 필요).
  - 표준 응답 래퍼(ApiResponse)로 데이터 제공, 사용자 미존재 시 404 처리.

- 문서화
  - Swagger에 사용자 정보 조회 엔드포인트 문서 추가.
  - 응답 코드 및 스키마 명시(200, 401, 404), 파라미터/보안 요건 반영.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->